### PR TITLE
ci(build): mirror Nexus-Setup.exe to the R2 builds bucket on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,6 +423,35 @@ jobs:
           # whose hash it can't read from an author-published SHA256SUMS.
           gh release upload $tag nexus-service/installer/output/Nexus-Setup.exe nexus-service/installer/output/SHA256SUMS --clobber
 
+      # Mirror the offline installer to the R2 `builds` bucket at an immutable
+      # versioned key. The Microsoft Store listing points at this URL: an
+      # EXE/MSI submission needs a direct link whose bytes never change, and a
+      # GitHub release asset 302s to a short-lived signed URL that Partner
+      # Center rejects.
+      - name: mirror installer to R2
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.version != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          VERSION_INPUT: ${{ inputs.version }}
+        shell: pwsh
+        run: |
+          $tag = if ($env:VERSION_INPUT -ne '') { "v$($env:VERSION_INPUT)" } else { $env:GITHUB_REF_NAME }
+          $key = "installers/$tag/Nexus-Setup.exe"
+          aws s3api head-object --endpoint-url $env:ENDPOINT --bucket builds --key $key 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "$key already exists; a published version is immutable. Skipping."
+            exit 0
+          }
+          aws s3api put-object --endpoint-url $env:ENDPOINT --bucket builds --key $key `
+            --body nexus-service/installer/output/Nexus-Setup.exe `
+            --content-type application/octet-stream `
+            --cache-control 'public, max-age=31536000, immutable'
+          if ($LASTEXITCODE -ne 0) { throw "R2 upload failed for $key" }
+          Write-Host "https://builds.hellonexus.com/$key"
+
   # The Windows WEB installers: payload-free Inno stubs that download the
   # current Nexus-Setup.exe at install time. Published to their own repo
   # (hello-nexus/nexus-installer, a release per StubVersion) so


### PR DESCRIPTION
Publishes each tagged release's offline installer to `builds.hellonexus.com/installers/<tag>/Nexus-Setup.exe` alongside the GitHub release asset.

**Why:** the Microsoft Store EXE/MSI listing requires a direct HTTPS URL whose bytes never change. A GitHub release asset 302-redirects to a short-lived signed `release-assets.githubusercontent.com` URL, which Partner Center rejects.

`head-object` guards the key, so re-running an existing tag skips rather than overwriting a version the Store already points at, and a failed upload throws instead of passing silently.

Requires repo secrets `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (set 2026-09-07, token scoped to the `builds` bucket).

Verified manually for `v3.0.11-beta.2`: uploaded, SHA256 matches the release `SHA256SUMS`, and the public URL returns 200 with zero redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HN9N3WuZaaskmfEbphvQh