### PR TITLE
fix(linux): add tested recovery helper for Y70, fans and Plasma startup

### DIFF
--- a/.github/workflows/linux-setup.yml
+++ b/.github/workflows/linux-setup.yml
@@ -1,0 +1,21 @@
+name: Linux setup helper
+on:
+  pull_request:
+    paths: ['scripts/linux-setup/**', '.github/workflows/linux-setup.yml']
+  push:
+    paths: ['scripts/linux-setup/**', '.github/workflows/linux-setup.yml']
+permissions:
+  contents: read
+jobs:
+  isolated-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: bash scripts/linux-setup/tests/static.sh
+      - run: bash scripts/linux-setup/tests/helper.sh
+      - run: node --test scripts/linux-setup/tests/simulator.test.cjs

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Installer downloads are published as GitHub Releases on this repository. The
 in-app updater compares against the latest semver `vX.Y.Z` tag; prerelease tags
 (`vX.Y.Z-beta.N`) are the beta channel.
 
+## Linux recovery helper
+
+For missing motherboard fans, a missing Plasma tray icon, or Y70 panel/editor
+startup problems, see the optional [Linux recovery helper](scripts/linux-setup/README.md).
+It includes the fixes developed on a Plasma 6 / Wayland Y70 system, diagnostics,
+and an uninstall command. It is run manually and is not part of the installer.
+
 ## Building from source
 
 A build you make yourself is fully local: devices, lighting, cooling, panels,

--- a/docs/linux-component-followups.md
+++ b/docs/linux-component-followups.md
@@ -1,0 +1,114 @@
+# Upstream implementation notes
+
+These are source-level contracts rather than fabricated file paths. The public
+umbrella repository currently states that its component repositories are still
+private, so the exact private source tree cannot be truthfully patched from the
+public checkout.
+
+## nexus-service: Y70 launcher
+
+When physical Y70 hardware has a stable panel association:
+
+```text
+panelRecordId != null
+```
+
+construct the local kiosk route from that identity:
+
+```text
+http://localhost:9400/panel/<url-encoded-panelRecordId>
+```
+
+Use generic `/panel` only when allocation is actually required.
+
+Acceptance condition: no viewport observed during browser startup can change an
+already-bound hardware Y70's record surface to `phone`.
+
+## nexus-service: Linux cooling
+
+Cooling discovery should tolerate providers appearing after process startup.
+A robust sequence is:
+
+```text
+service starts
+  -> enumerate current hwmon PWM providers
+  -> optionally perform supported, read-only module/provider probes
+  -> subscribe/retry for provider changes
+  -> add/remove Linux fan channels when providers change
+```
+
+Do not modify `pwmN`, `pwmN_enable`, curves or duty values merely to discover a
+provider.
+
+## nexus-service: graphical session
+
+Separate hardware lifetime from session lifetime:
+
+```text
+service starts
+  -> hardware monitoring/control starts immediately
+  -> no eligible graphical user: session integration = pending
+  -> graphical session appears
+  -> adopt user environment + register tray/MPRIS/etc.
+  -> session disappears/changes
+  -> detach and retry/adopt the current eligible session
+```
+
+A failed first adoption should not require a daemon restart.
+
+## nexus-web: simulator protocol
+
+Treat each iframe document as a new protocol peer.
+
+Conceptual parent state:
+
+```text
+peerReady = false
+peerInitialized = false
+```
+
+On iframe load, clear both flags.
+
+On `simulator/ready`:
+
+```text
+peerReady = true
+if complete current state is available:
+    send simulator/init {
+      surface,
+      deviceTouch,
+      dpi,
+      displayBound,
+      layout,
+      theme,
+      themeMode,
+      selectedWidgetId,
+      brightness,
+      screenOn,
+      showPanel,
+      deviceId
+    }
+    peerInitialized = true
+else:
+    remember peerReady and initialize when state becomes available
+```
+
+Send incremental simulator messages only after the peer has been initialized,
+or queue them behind init.
+
+## `showPanel`
+
+Do not equate:
+
+```text
+panel.autoLaunch == false
+```
+
+with:
+
+```text
+physical panel is hidden
+```
+
+`autoLaunch` is desired launch policy. `showPanel` is runtime visibility/state.
+Use active panel session/binding/display state when available.

--- a/docs/linux-recovery.md
+++ b/docs/linux-recovery.md
@@ -1,0 +1,58 @@
+# Linux recovery: what failed and what this change does
+
+This contribution brings the working recovery helper from
+[Ottomatic-Mike/nexus-linux-setup](https://github.com/Ottomatic-Mike/nexus-linux-setup/tree/510cd4f)
+into `scripts/linux-setup`, with its MIT attribution preserved. The original
+Nexus README, license, installer, and submodule revisions remain intact.
+
+The original work reports successful recovery on Kubuntu, Plasma 6/Wayland,
+a HYTE Y70 Touch and an ASUS X870E board with an NCT6799-compatible fan chip,
+using the Nexus 3.0.12 beta line. That hardware result belongs to the original
+work; this contribution was checked with isolated tests, without running setup,
+changing the host, restarting Nexus or touching hardware.
+
+| Observed problem | Executable recovery included here | Long-term component change |
+| --- | --- | --- |
+| Y70 starts with another monitor's dimensions and becomes a phone panel | Reuse the existing Y70 record at `/panel/<id>`; place its Chrome window with KWin, leaving KScreen configuration alone | Launch associated physical panels using their stored identity |
+| Editor receives theme/layout updates but no initial state and stays blank | After 250 ms, synthesize one init from received Y70 theme/layout unless a real init arrives; keep the direct kiosk preview visible | Parent sends full init after each iframe ready/load before incremental updates |
+| Only GPU fans appear because motherboard hwmon loads late | Probe `nct6775`; persist a preload only if supported NCT PWM channels appear; restart Nexus for enumeration | Rediscover cooling providers after startup |
+| Hardware runs but the Plasma tray is absent after login | Optional, bounded wait for the selected user's Plasma process | Retry graphical session adoption independently of hardware lifetime |
+
+The helper also preserves the original local-token profile bootstrap, consistent
+`localhost` URL, update-time marked HTML patch, diagnostics, backups, and removal
+commands. It makes no direct PWM writes. It does not repair RGB internals; its
+lighting check only reports matching journal activity.
+
+## Why this is an optional helper
+
+The public repository is an umbrella. The `nexus-service` and `nexus-web`
+repositories were inaccessible with the contributor's account when preparing
+this change. This PR therefore adds code that can actually run from this public
+repository, rather than claiming to fix inaccessible component code.
+
+Nothing runs automatically when cloning, building, or installing Nexus.
+Users explicitly invoke the [helper](../scripts/linux-setup/README.md).
+The Plasma gate is opt-in because delaying the hardware daemon is not a durable
+solution. The simulator fallback is also a workaround, including its Y70
+visibility override; it should be retired when the protocol is fixed upstream.
+
+The [reproduction](linux-reproduction.md) records the original observations.
+The [component follow-ups](linux-component-followups.md) describe the internal
+changes and acceptance conditions for maintainers with source access.
+
+## Validation
+
+Run from the repository root:
+
+```bash
+bash scripts/linux-setup/tests/static.sh
+bash scripts/linux-setup/tests/helper.sh
+node --test scripts/linux-setup/tests/simulator.test.cjs
+```
+
+These tests use temporary fixtures and simulated browser messages. They do not
+run install/repair, systemctl, sudo, modprobe, Chrome, or KWin on the host.
+Real hardware validation is still needed for fresh install, logout/login,
+suspend/resume, profile authentication, update/reapply, and uninstall on the
+maintainer's supported configurations. Component lint/build/tests cannot be run
+without the private component repositories.

--- a/docs/linux-reproduction.md
+++ b/docs/linux-reproduction.md
@@ -1,0 +1,87 @@
+# Reproduction checklist
+
+Sanitized environment used for the verified reproduction:
+
+```text
+Desktop:     KDE Plasma 6 / Wayland
+Panel:       HYTE Y70 Touch, native 3840x1100, portrait
+Nexus:       v3.0.12 beta line
+Kernel:      Ubuntu 7.0.0-31-generic
+Motherboard: ASUS ROG STRIX X870E-E GAMING WIFI
+Fan chip:    NCT6799-compatible
+```
+
+## A. Y70 identity
+
+1. Configure the Y70 as a normal extended KScreen output.
+2. Let Nexus auto-launch generic `/panel`.
+3. Exercise login/startup, service restart, suspend/resume, or hibernate/resume.
+4. Observe the kiosk before final KWin placement.
+5. Inspect the panel records/capabilities.
+
+Failure: a `phone`-surface record is allocated/updated for the physical kiosk,
+or the kiosk binds to the wrong record.
+
+Control: direct `/panel/<known-y70-record-id>` stays on the correct stored Y70
+layout.
+
+## B. Simulator
+
+1. Open the Y70 device editor.
+2. Inspect the same-origin `/panel?simulator=1` iframe.
+3. Listen for `message` events in the iframe.
+4. Reload the iframe or reproduce the editor state loss.
+
+Observed failure sequence:
+
+```text
+simulator/ready
+simulator/set-theme
+simulator/set-layout
+(no simulator/init)
+```
+
+Control: one complete `simulator/init` immediately renders the saved Y70
+layout.
+
+## C. Motherboard fans
+
+Before module load:
+
+```bash
+for h in /sys/class/hwmon/hwmon*; do
+  cat "$h/name" 2>/dev/null
+  ls "$h"/pwm[0-9] 2>/dev/null || true
+done
+```
+
+On the reproduced board there were no motherboard PWM attributes.
+
+Load the in-tree provider:
+
+```bash
+sudo modprobe nct6775
+```
+
+Expected kernel identification on this board:
+
+```text
+NCT6796D-S/NCT6799D-R or compatible chip
+```
+
+Expected hwmon provider: `nct6799` with seven PWM channels.
+
+Restart Nexus only. Expected log:
+
+```text
+[Motherboard] Fans channels=7 id=linux-fans
+```
+
+## D. Plasma tray race
+
+1. Allow the system service to start before the user's Plasma session exists.
+2. Log into Plasma.
+3. Confirm Nexus hardware service is running but tray is absent.
+4. Restart `nexus.service` after `plasmashell` exists.
+
+Control: tray appears after the restart.

--- a/scripts/linux-setup/LICENSE
+++ b/scripts/linux-setup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nexus Linux Setup Helper contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/linux-setup/README.md
+++ b/scripts/linux-setup/README.md
@@ -1,0 +1,283 @@
+# Nexus Linux Setup Helper
+
+An **unofficial** setup and repair helper for the open-source
+[`hello-nexus/nexus`](https://github.com/hello-nexus/nexus) hardware monitoring,
+fan control and RGB suite.
+
+This repository automates the complete Linux setup that was proven on a real
+Kubuntu/Plasma + HYTE Y70 system after several independent startup failures were
+isolated and fixed.
+
+## One-command setup
+
+```bash
+chmod +x nexus-linux-setup.sh
+./nexus-linux-setup.sh install
+```
+
+For an existing Nexus installation:
+
+```bash
+./nexus-linux-setup.sh repair
+```
+
+Then verify everything:
+
+```bash
+./nexus-linux-setup.sh doctor
+```
+
+## What it automates
+
+The helper:
+
+- installs the current official Nexus Linux x86-64 release from
+  `hello-nexus/nexus` unless Nexus is already present;
+- deliberately runs Nexus's own `install.sh` rather than inventing a private
+  installation layout;
+- detects whether `nct6775` exposes a real NCT67xx/NCT679x PWM controller and,
+  only when it does, guarantees that driver is loaded before Nexus enumerates
+  cooling hardware;
+- with `--wait-for-plasma` on KDE Plasma, waits up to 30 seconds for the active Plasma
+  session so its tray integration is established reliably;
+- detects the existing Y70-shaped KScreen output without changing resolution,
+  scale, rotation or desktop placement;
+- converts the physical Y70 kiosk from the fragile generic `/panel` route to a
+  stable `/panel/<record-id>` route;
+- installs a KWin 6 placement helper that targets only the managed Nexus kiosk;
+- uses `localhost` consistently so Chrome's app/window class stays stable;
+- seeds a dedicated Chrome profile once, while never writing the Nexus bearer
+  token into a service unit or state file;
+- applies the proven local simulator/editor handshake workaround and reapplies
+  it after Nexus updates replace `wwwroot/index.html`;
+- provides `doctor`, `repair`, `status`, and `uninstall` commands.
+
+## Safety boundaries
+
+This helper **does not**:
+
+- write motherboard PWM duty values itself;
+- change KScreen monitor mode, scale, rotation or desktop geometry;
+- store Nexus authentication tokens in systemd units, helper state or logs;
+- delete Nexus user data during a normal uninstall;
+- replace Nexus's official installer with a custom binary layout;
+- change unrelated KWin settings.
+
+Actual fan policy and RGB behavior remain Nexus's responsibility.
+
+## Verified environment
+
+The complete flow was developed and verified with:
+
+```text
+Linux:       Kubuntu / KDE Plasma 6 / Wayland
+Panel:       HYTE Y70 Touch, native 3840x1100, portrait
+Nexus:       3.0.12 beta line
+Kernel:      Ubuntu 7.0.0-31-generic
+Motherboard: ASUS ROG STRIX X870E-E GAMING WIFI
+Fan chip:    NCT6799-compatible via nct6775
+```
+
+The script is deliberately capability-driven rather than hard-coded to those
+identifiers. It skips a feature when it cannot safely prove that feature
+applies.
+
+## Commands
+
+### Install or fully configure
+
+```bash
+./nexus-linux-setup.sh install
+```
+
+### Repair an existing installation
+
+```bash
+./nexus-linux-setup.sh repair
+```
+
+### Read-only health check
+
+```bash
+./nexus-linux-setup.sh doctor
+```
+
+### Show managed state
+
+```bash
+./nexus-linux-setup.sh status
+```
+
+### Remove only this helper's integration
+
+```bash
+./nexus-linux-setup.sh uninstall
+```
+
+This keeps the official Nexus installation, Nexus user data and the dedicated
+Chrome kiosk profile.
+
+To additionally invoke Nexus's own uninstaller when available:
+
+```bash
+./nexus-linux-setup.sh uninstall --purge-nexus
+```
+
+### Install a specific official release
+
+```bash
+./nexus-linux-setup.sh install --version v3.0.12-beta.2
+```
+
+### Use an official archive already downloaded
+
+```bash
+./nexus-linux-setup.sh install --archive ~/Downloads/<nexus-linux-x64.tar.gz>
+```
+
+## Why the Y70 workaround exists
+
+Nexus's generic `/panel` bootstrap derives the panel surface from the browser's
+runtime viewport. During Wayland/KWin startup or resume, Chrome can briefly have
+the geometry of another monitor before final placement. That can cause the
+physical Y70 kiosk to be allocated or updated as a `phone` panel.
+
+The stable workaround is to use the already-associated Y70 record directly:
+
+```text
+http://localhost:9400/panel/<y70-record-id>
+```
+
+The helper discovers that record and builds the user service dynamically. It
+never hard-codes a machine-specific panel ID, connector name, UID or geometry.
+
+## Why the simulator/editor workaround exists
+
+The embedded `/panel?simulator=1` frame starts with an empty layout and an
+independent `ready` state. In the reproduced failure the child emitted
+`simulator/ready`, then received incremental `simulator/set-theme` and
+`simulator/set-layout` messages, but did not receive the complete
+`simulator/init` required to initialize it.
+
+The local patch waits briefly for a real init. If none arrives after the real
+theme and layout are known, it synthesizes one from those real values. Because
+this helper intentionally uses an external direct Y70 launcher while Nexus's
+built-in `panel.autoLaunch` is disabled, the patch also keeps the editor's
+`showPanel` state aligned with the actually visible direct kiosk.
+
+The injection is bounded to the simulator iframe and surrounded by explicit
+HTML markers so it can be removed cleanly.
+
+## Why motherboard fans were missing
+
+On the verified ASUS X870E system, Nexus initially started before `nct6775` was
+loaded. Linux exposed no writable motherboard PWM channels, so Nexus could only
+control the NVIDIA GPU fan.
+
+After a safe module load:
+
+```bash
+sudo modprobe nct6775
+```
+
+Linux exposed an `nct6799` hwmon device with seven PWM channels. Restarting
+Nexus immediately produced:
+
+```text
+[Motherboard] Fans channels=7 id=linux-fans
+```
+
+The helper automates only that discovery/preload step. It never writes a PWM
+value.
+
+## Why the Plasma startup gate exists
+
+The current Linux Nexus service runs as a root hardware daemon and adopts the
+active user session for tray/MPRIS integration. On the reproduced system the
+service could start before `plasmashell`; hardware worked but the tray icon was
+absent until Nexus was restarted after login.
+
+The opt-in local workaround waits up to 30 seconds for the target user's Plasma process before starting
+Nexus. The upstream proposal is better: keep the hardware daemon independent
+and make session/tray adoption retryable.
+
+## Files installed by this helper
+
+Depending on detected capabilities, the helper may manage:
+
+```text
+/etc/nexus-linux-setup/
+/etc/modules-load.d/nexus-fans.conf
+/etc/systemd/system/nexus.service.d/10-wait-for-plasma.conf
+/etc/systemd/system/nexus.service.d/15-y70-simulator.conf
+/etc/systemd/system/nexus.service.d/20-nct6775.conf
+/usr/local/libexec/nexus-linux-setup
+/usr/local/share/nexus-linux-setup/simulator-fix.js
+~/.config/systemd/user/nexus-y70-direct.service
+~/.local/bin/nexus-y70-direct
+~/.local/share/kwin/scripts/nexus-y70-placement/
+```
+
+Original files touched by the web/settings work are copied by content hash into
+`/etc/nexus-linux-setup/backups/` before modification.
+
+## Updates
+
+To run the official release installer/update path and then reapply this helper:
+
+```bash
+./nexus-linux-setup.sh install --update
+```
+
+The system service also calls the helper's idempotent web-patch action before
+Nexus starts, so a replaced `index.html` is patched again automatically.
+
+## Diagnostics
+
+`doctor` checks the service, localhost dashboard, Plasma startup gate,
+NCT PWM exposure, Nexus's own motherboard-fan enumeration log, simulator patch,
+direct Y70 user service/route and basic lighting/OpenRGB log activity.
+
+A shell script cannot visually inspect whether a tray glyph is painted; it
+verifies the startup condition that fixed the tray race on the reproduced
+system.
+
+See [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) for manual checks.
+
+## Origin and scope
+
+Adapted from [nexus-linux-setup](https://github.com/Ottomatic-Mike/nexus-linux-setup)
+commit `510cd4f`, developed on the environment above. This is an optional recovery
+helper, not a replacement for component-level fixes. See
+[the maintainer notes](../../docs/linux-recovery.md) for the failure-to-fix map.
+
+### Changes made for this contribution
+
+- Download progress goes to stderr so command substitution receives only the archive path.
+- The Plasma startup gate requires `--wait-for-plasma` and stops waiting after
+  30 seconds. Hardware startup must not depend indefinitely on a desktop login.
+- The simulator workaround is installed only when configuring a direct Y70 kiosk,
+  and only changes simulator state after receiving an explicit Y70 layout.
+- Multiple Y70 records require an explicit `NEXUS_PANEL_ID`; the output fallback
+  requires portrait geometry so ordinary ultrawide monitors are not selected.
+- Panel IDs are validated before generating launchers; browser output during
+  token seeding is discarded to avoid recording authentication URLs.
+- Setup no longer deletes the earlier diagnostic KWin script automatically.
+
+Requirements: Linux x86-64 with systemd, Bash, Python 3, curl, sudo, kmod and
+standard GNU utilities. Y70 integration additionally needs a logged-in Plasma 6
+Wayland session, KScreen, KWin tools and Chrome/Chromium. Finish Nexus onboarding
+first. Run the commands above from `scripts/linux-setup` in this repository.
+The default download searches the most recent 20 releases and may select a beta;
+use an explicit version or local archive for reproducible installation.
+
+The direct-profile seeding step uses a six-second browser launch and does not
+prove authentication succeeded. Check the actual panel after setup. Uninstall
+reenables Nexus panel auto-launch rather than restoring its previous value;
+content-hash backups remain under `/etc/nexus-linux-setup/backups`. The optional
+Plasma gate is a startup workaround, not support for session reconnection.
+
+## License
+
+MIT for this helper. Nexus itself is licensed separately by its maintainers.
+This project is not an official Nexus distribution.

--- a/scripts/linux-setup/assets/simulator-fix.js
+++ b/scripts/linux-setup/assets/simulator-fix.js
@@ -1,0 +1,108 @@
+(() => {
+  const qs = new URLSearchParams(location.search);
+  if (window.parent === window || location.pathname !== "/panel" || qs.get("simulator") !== "1") return;
+
+  const state = {
+    theme: null,
+    themeMode: "dark",
+    layout: null,
+    deviceId: null,
+    deviceTouch: undefined,
+    dpi: undefined,
+    displayBound: false,
+    selectedWidgetId: null,
+    brightness: 100,
+    screenOn: true
+  };
+
+  let sawRealInit = false;
+  let syntheticInitSent = false;
+  let initTimer = null;
+
+  function visibleDisplay() {
+    if (state.layout?.surface !== "y70") return;
+    window.postMessage({
+      type: "simulator/set-display",
+      brightness: state.brightness,
+      screenOn: state.screenOn,
+      showPanel: true
+    }, location.origin);
+  }
+
+  function maybeInit() {
+    if (sawRealInit || syntheticInitSent || !state.theme || state.layout?.surface !== "y70" || initTimer) return;
+    initTimer = setTimeout(() => {
+      initTimer = null;
+      if (sawRealInit || syntheticInitSent || !state.theme || state.layout?.surface !== "y70") return;
+      syntheticInitSent = true;
+      window.postMessage({
+        type: "simulator/init",
+        surface: state.layout.surface || "y70",
+        deviceTouch: state.deviceTouch,
+        dpi: state.dpi,
+        displayBound: state.displayBound,
+        layout: state.layout,
+        theme: state.theme,
+        themeMode: state.themeMode,
+        selectedWidgetId: state.selectedWidgetId,
+        brightness: state.brightness,
+        screenOn: state.screenOn,
+        showPanel: true,
+        deviceId: state.deviceId
+      }, location.origin);
+    }, 250);
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.origin !== location.origin || event.source !== window.parent || !event.data || typeof event.data !== "object") return;
+    const msg = event.data;
+
+    switch (msg.type) {
+      case "simulator/init":
+        sawRealInit = true;
+        if (initTimer) clearTimeout(initTimer);
+        initTimer = null;
+        state.theme = msg.theme ?? state.theme;
+        state.themeMode = msg.themeMode ?? state.themeMode;
+        state.layout = msg.layout ?? state.layout;
+        state.deviceId = msg.deviceId ?? state.deviceId;
+        state.deviceTouch = msg.deviceTouch;
+        state.dpi = msg.dpi;
+        state.displayBound = msg.displayBound ?? state.displayBound;
+        state.selectedWidgetId = msg.selectedWidgetId ?? state.selectedWidgetId;
+        state.brightness = msg.brightness ?? state.brightness;
+        state.screenOn = msg.screenOn ?? state.screenOn;
+        setTimeout(visibleDisplay, 0);
+        return;
+
+      case "simulator/set-theme":
+        state.theme = msg.theme ?? state.theme;
+        state.themeMode = msg.themeMode ?? state.themeMode;
+        state.deviceId = msg.deviceId ?? state.deviceId;
+        break;
+      case "simulator/set-layout":
+        state.layout = msg.layout ?? state.layout;
+        break;
+      case "simulator/set-grid":
+        state.dpi = msg.dpi;
+        break;
+      case "simulator/set-touch":
+        state.deviceTouch = msg.deviceTouch;
+        break;
+      case "simulator/set-display-bound":
+        state.displayBound = msg.displayBound;
+        break;
+      case "simulator/set-selection":
+        state.selectedWidgetId = msg.widgetId ?? null;
+        break;
+      case "simulator/set-display":
+        state.brightness = msg.brightness ?? state.brightness;
+        state.screenOn = msg.screenOn ?? state.screenOn;
+        if (msg.showPanel !== true) setTimeout(visibleDisplay, 0);
+        break;
+      default:
+        break;
+    }
+    maybeInit();
+  }, true);
+})();

--- a/scripts/linux-setup/docs/TECHNICAL-NOTES.md
+++ b/scripts/linux-setup/docs/TECHNICAL-NOTES.md
@@ -1,0 +1,71 @@
+# Technical notes
+
+## Stable physical-panel identity
+
+The physical display's identity must not depend on the initial browser viewport.
+A direct `/panel/<record-id>` route bypasses allocation and therefore prevents a
+short-lived startup geometry from rewriting a known Y70 into another surface.
+
+The helper always uses `localhost`. Chromium/Chrome derives the app class from
+the URL, so switching to `127.0.0.1` creates a different class and can break a
+window-placement rule.
+
+## Token handling
+
+For a new direct kiosk profile the helper may need Nexus's local bearer token
+once. It obtains it only from Nexus's own already-running local kiosk command
+line during setup, uses it to open the direct route once, then relies on the
+browser profile's persisted local authentication.
+
+The helper does not write the token to its state file, launcher, user unit or
+log output.
+
+## KScreen versus KWin responsibility
+
+KScreen owns the user's monitor mode, scale, rotation and desktop arrangement.
+The verified failure did not require changing any of those values. KWin only
+needs to place the Nexus kiosk window on the already-configured output.
+
+The generated KWin 6 script therefore reads `workspace.screens`, matches the
+single direct Nexus app class, uses the output geometry for `frameGeometry`,
+and applies fullscreen/no-border/task-switcher properties only to that window.
+
+## Fan discovery
+
+The verified board uses an NCT6799-compatible Super-I/O chip. Loading the
+in-tree `nct6775` module created seven `pwmN` channels. Nexus discovered them on
+the next service start.
+
+The helper treats module insertion as discovery only. It makes no raw PWM
+writes, leaves `pwmN_enable` untouched and lets Nexus own cooling policy.
+
+## Simulator protocol
+
+The observed child protocol recognizes:
+
+```text
+simulator/ready
+simulator/init
+simulator/set-layout
+simulator/set-grid
+simulator/set-touch
+simulator/set-display-bound
+simulator/set-theme
+simulator/set-selection
+simulator/flash-widget
+simulator/set-display
+```
+
+The child starts with `ready=false` and an empty layout. Only
+`simulator/init` sets `ready=true`. That makes complete initialization a
+protocol requirement, not merely an optimization.
+
+The workaround waits for real theme + layout state, allows a short window for a
+real init, then synthesizes one only if the peer still has not been initialized.
+
+## Service/session architecture
+
+The local Plasma gate is intentionally conservative. The upstream design should
+be different: hardware service startup should not depend on a desktop login.
+Session-dependent capabilities such as tray/MPRIS should attach, detach and
+reattach as graphical sessions appear or change.

--- a/scripts/linux-setup/docs/TROUBLESHOOTING.md
+++ b/scripts/linux-setup/docs/TROUBLESHOOTING.md
@@ -1,0 +1,113 @@
+# Troubleshooting
+
+## Start with the health check
+
+```bash
+sudo ./nexus-linux-setup.sh doctor
+```
+
+## Nexus service will not stop cleanly
+
+The helper already uses a bounded stop followed by a service-scoped SIGKILL
+fallback. To reproduce that manually:
+
+```bash
+sudo systemctl stop nexus &
+sleep 5
+sudo systemctl kill --kill-whom=all --signal=SIGKILL nexus 2>/dev/null || true
+wait
+```
+
+## Y70 direct service is configured but inactive
+
+```bash
+systemctl --user status nexus-y70-direct.service
+journalctl --user -u nexus-y70-direct.service -b --no-pager
+```
+
+The launcher waits for `http://localhost:9400` before Chrome starts.
+
+## Y70 output is not detected
+
+```bash
+kscreen-doctor -o
+```
+
+A classic Y70 Touch normally exposes a `3840x1100` mode. The helper strongly
+prefers that signature and otherwise uses a portrait display ratio of at least 2.5. It
+refuses to guess if equally strong candidates exist.
+
+The helper never modifies the KScreen mode, scale, rotation or position.
+
+## Motherboard fans are absent
+
+```bash
+lsmod | grep nct6775
+for h in /sys/class/hwmon/hwmon*; do
+  printf '%s: ' "$h"
+  cat "$h/name" 2>/dev/null || true
+  ls "$h"/pwm[0-9] 2>/dev/null || true
+done
+```
+
+Then inspect what Nexus enumerated:
+
+```bash
+journalctl -u nexus -b --no-pager | grep -Ei 'cool|fan|pwm|nct'
+```
+
+The helper persists `nct6775` only when the module really exposes a supported
+NCT PWM controller.
+
+## Tray icon is absent
+
+```bash
+pgrep -a plasmashell
+systemctl status nexus
+systemctl cat nexus
+```
+
+On Plasma, opt in with `repair --wait-for-plasma`. It waits at most 30 seconds
+and appears as:
+
+```text
+/etc/systemd/system/nexus.service.d/10-wait-for-plasma.conf
+```
+
+To install the tray startup workaround, run:
+
+```bash
+sudo ./nexus-linux-setup.sh repair --wait-for-plasma
+```
+
+## Editor says Panel hidden / Desktop visible
+
+Check whether the marked local patch exists:
+
+```bash
+sudo grep -n 'BEGIN nexus-linux-setup simulator fix' /opt/nexus/wwwroot/index.html
+```
+
+Then repair:
+
+```bash
+sudo ./nexus-linux-setup.sh repair
+```
+
+## Nexus update replaced the app files
+
+```bash
+sudo ./nexus-linux-setup.sh repair
+```
+
+The service drop-in also reapplies the simulator patch automatically on the
+next Nexus start.
+
+## Undo the helper
+
+```bash
+sudo ./nexus-linux-setup.sh uninstall
+```
+
+This restores Nexus's own `panel.autoLaunch` behavior and removes the managed
+service/KWin/module integration while preserving Nexus user data.

--- a/scripts/linux-setup/nexus-linux-setup.sh
+++ b/scripts/linux-setup/nexus-linux-setup.sh
@@ -1,0 +1,729 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+VERSION="1.0.0"
+ORIGINAL_ARGS=("$@")
+PROJECT="nexus-linux-setup"
+OFFICIAL_REPO="hello-nexus/nexus"
+NEXUS_URL="http://localhost:9400"
+STATE_DIR="/etc/${PROJECT}"
+STATE_FILE="${STATE_DIR}/state.env"
+BACKUP_DIR="${STATE_DIR}/backups"
+SHARE_DIR="/usr/local/share/${PROJECT}"
+LIBEXEC="/usr/local/libexec/${PROJECT}"
+DROPIN_DIR="/etc/systemd/system/nexus.service.d"
+
+NO_Y70=0
+WAIT_FOR_PLASMA=0
+FORCE_UPDATE=0
+PURGE_NEXUS=0
+NEXUS_VERSION=""
+LOCAL_ARCHIVE=""
+QUIET=0
+
+log(){ [[ "$QUIET" -eq 1 ]] || printf '[%s] %s\n' "$PROJECT" "$*" >&2; }
+warn(){ printf '[%s] WARNING: %s\n' "$PROJECT" "$*" >&2; }
+die(){ printf '[%s] ERROR: %s\n' "$PROJECT" "$*" >&2; exit 1; }
+
+usage(){
+cat <<'EOF'
+Nexus Linux Setup Helper (unofficial)
+
+Usage:
+  ./nexus-linux-setup.sh install [options]
+  ./nexus-linux-setup.sh repair [options]
+  ./nexus-linux-setup.sh doctor
+  ./nexus-linux-setup.sh status
+  ./nexus-linux-setup.sh uninstall [--purge-nexus]
+
+Options:
+  --version TAG       Install a specific official Nexus release tag.
+  --archive FILE      Install from an already-downloaded official Linux tarball.
+  --update            Re-run the official installer/update path.
+  --no-y70            Skip Y70-specific integration.
+  --wait-for-plasma   Opt in to a bounded (30s) tray startup workaround.
+  --purge-nexus       With uninstall, also invoke Nexus's own uninstaller if found.
+  --quiet             Reduce normal output.
+
+Environment overrides:
+  NEXUS_SETUP_USER    Desktop user to configure.
+  NEXUS_PANEL_ID      Existing Y70 panel record ID.
+  NEXUS_CHROME        Chrome/Chromium executable.
+
+The helper never changes KScreen resolution, scale, rotation, or monitor layout.
+It never writes PWM values itself and never stores a Nexus bearer token in a
+systemd unit or state file.
+EOF
+}
+
+need_root(){
+  if [[ "$EUID" -ne 0 ]]; then
+    local u="${NEXUS_SETUP_USER:-${USER:-}}"
+    exec sudo -E env NEXUS_SETUP_USER="$u" "$0" "${ORIGINAL_ARGS[@]}"
+  fi
+}
+
+detect_desktop_user(){
+  if [[ -n "${NEXUS_SETUP_USER:-}" ]] && id "$NEXUS_SETUP_USER" >/dev/null 2>&1; then
+    printf '%s\n' "$NEXUS_SETUP_USER"; return
+  fi
+  if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != root ]] && id "$SUDO_USER" >/dev/null 2>&1; then
+    printf '%s\n' "$SUDO_USER"; return
+  fi
+  local p uid u
+  p="$(pgrep -o -x plasmashell 2>/dev/null || true)"
+  if [[ -n "$p" ]]; then
+    uid="$(stat -c '%u' "/proc/$p" 2>/dev/null || true)"
+    u="$(getent passwd "$uid" | cut -d: -f1)"
+    [[ -n "$u" ]] && { printf '%s\n' "$u"; return; }
+  fi
+  die "Could not determine the desktop user. Set NEXUS_SETUP_USER=<username>."
+}
+
+init_user(){
+  DESKTOP_USER="$(detect_desktop_user)"
+  DESKTOP_UID="$(id -u "$DESKTOP_USER")"
+  DESKTOP_GID="$(id -g "$DESKTOP_USER")"
+  DESKTOP_HOME="$(getent passwd "$DESKTOP_USER" | cut -d: -f6)"
+  USER_RUNTIME="/run/user/${DESKTOP_UID}"
+  USER_BUS="unix:path=${USER_RUNTIME}/bus"
+  USER_ENV=("HOME=$DESKTOP_HOME" "USER=$DESKTOP_USER" "LOGNAME=$DESKTOP_USER" "XDG_RUNTIME_DIR=$USER_RUNTIME" "DBUS_SESSION_BUS_ADDRESS=$USER_BUS")
+
+  local p kv
+  p="$(pgrep -u "$DESKTOP_UID" -o -x plasmashell 2>/dev/null || true)"
+  if [[ -n "$p" && -r "/proc/$p/environ" ]]; then
+    while IFS= read -r kv; do
+      case "$kv" in
+        DISPLAY=*|WAYLAND_DISPLAY=*|XDG_CURRENT_DESKTOP=*|XDG_SESSION_DESKTOP=*|XDG_SESSION_TYPE=*) USER_ENV+=("$kv") ;;
+      esac
+    done < <(tr '\0' '\n' < "/proc/$p/environ")
+  fi
+}
+
+as_user(){ sudo -u "$DESKTOP_USER" env "${USER_ENV[@]}" "$@"; }
+
+ensure_dirs(){
+  install -d -m 0700 "$STATE_DIR" "$BACKUP_DIR"
+  install -d -m 0755 "$SHARE_DIR" "$(dirname "$LIBEXEC")"
+}
+
+backup_file(){
+  local f="$1" sha out
+  [[ -f "$f" ]] || return 0
+  sha="$(sha256sum "$f" | awk '{print $1}')"
+  out="${BACKUP_DIR}/$(basename "$f").${sha}"
+  [[ -e "$out" ]] || cp -a "$f" "$out"
+}
+
+save_state(){
+  local t; t="$(mktemp)"
+  {
+    printf 'DESKTOP_USER=%q\n' "$DESKTOP_USER"
+    printf 'DESKTOP_UID=%q\n' "$DESKTOP_UID"
+    printf 'DESKTOP_HOME=%q\n' "$DESKTOP_HOME"
+    printf 'PANEL_ID=%q\n' "${PANEL_ID:-}"
+    printf 'Y70_OUTPUT=%q\n' "${Y70_OUTPUT:-}"
+    printf 'Y70_GEOMETRY=%q\n' "${Y70_GEOMETRY:-}"
+    printf 'CHROME_BIN=%q\n' "${CHROME_BIN:-}"
+    printf 'KIOSK_PROFILE=%q\n' "${KIOSK_PROFILE:-}"
+    printf 'FAN_MODULE=%q\n' "${FAN_MODULE:-}"
+  } > "$t"
+  install -m 0600 "$t" "$STATE_FILE"
+  rm -f "$t"
+}
+
+load_state(){ [[ -r "$STATE_FILE" ]] && source "$STATE_FILE" || true; }
+
+install_self(){
+  install -m 0755 "${BASH_SOURCE[0]}" "$LIBEXEC"
+  local asset="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assets/simulator-fix.js"
+  if [[ -f "$asset" ]]; then
+    install -m 0644 "$asset" "$SHARE_DIR/simulator-fix.js"
+  elif [[ ! -f "$SHARE_DIR/simulator-fix.js" ]]; then
+    die "Missing assets/simulator-fix.js"
+  fi
+}
+
+nexus_installed(){ [[ -x /opt/nexus/Nexus ]] && systemctl cat nexus.service >/dev/null 2>&1; }
+
+select_release_asset(){
+  local jsonfile="$1"
+  python3 - "$jsonfile" "$NEXUS_VERSION" <<'PY'
+import json, sys
+path, wanted = sys.argv[1], sys.argv[2].strip()
+with open(path, encoding='utf-8') as f:
+    releases=json.load(f)
+for rel in releases:
+    if rel.get('draft'): continue
+    tag=rel.get('tag_name','')
+    if wanted and tag != wanted: continue
+    for a in rel.get('assets',[]):
+        name=a.get('name',''); low=name.lower()
+        if not low.endswith(('.tar.gz','.tgz')): continue
+        if 'linux' not in low: continue
+        if not any(x in low for x in ('x64','x86_64','amd64')): continue
+        if any(x in low for x in ('sha256','checksum','symbols','debug')): continue
+        print(tag); print(name); print(a['browser_download_url']); raise SystemExit(0)
+raise SystemExit(2)
+PY
+}
+
+download_official_archive(){
+  local tmp="$1"
+  if [[ -n "$LOCAL_ARCHIVE" ]]; then
+    [[ -f "$LOCAL_ARCHIVE" ]] || die "Archive not found: $LOCAL_ARCHIVE"
+    cp -a "$LOCAL_ARCHIVE" "$tmp/nexus.tar.gz"
+    printf '%s\n' "$tmp/nexus.tar.gz"; return
+  fi
+  command -v curl >/dev/null || die "curl is required"
+  command -v python3 >/dev/null || die "python3 is required"
+  log "Querying official ${OFFICIAL_REPO} releases..."
+  curl -fsSL --retry 3 -H 'Accept: application/vnd.github+json' -H 'User-Agent: nexus-linux-setup' \
+    "https://api.github.com/repos/${OFFICIAL_REPO}/releases?per_page=20" -o "$tmp/releases.json" \
+    || die "Could not query official GitHub releases"
+  local selection tag name url
+  selection="$(select_release_asset "$tmp/releases.json")" || die "No matching Linux x86-64 release archive found"
+  tag="$(sed -n '1p' <<<"$selection")"; name="$(sed -n '2p' <<<"$selection")"; url="$(sed -n '3p' <<<"$selection")"
+  log "Downloading official Nexus ${tag}: ${name}"
+  curl -fL --retry 3 --progress-bar "$url" -o "$tmp/nexus.tar.gz"
+  printf '%s\n' "$tmp/nexus.tar.gz"
+}
+
+install_official_nexus(){
+  if nexus_installed && [[ "$FORCE_UPDATE" -eq 0 && -z "$LOCAL_ARCHIVE" && -z "$NEXUS_VERSION" ]]; then
+    log "Nexus is already installed; keeping the official installation."
+    return
+  fi
+  local tmp archive installer
+  tmp="$(mktemp -d)"
+  archive="$(download_official_archive "$tmp")"
+  mkdir -p "$tmp/extract"
+  tar -xzf "$archive" -C "$tmp/extract"
+  installer="$(find "$tmp/extract" -type f -name install.sh -print | head -1)"
+  [[ -n "$installer" ]] || { rm -rf "$tmp"; die "Official archive contained no install.sh; refusing to invent an install layout."; }
+  log "Running the official Nexus installer..."
+  (cd "$(dirname "$installer")" && bash "./$(basename "$installer")")
+  rm -rf "$tmp"
+  systemctl daemon-reload
+  nexus_installed || die "Official installer finished, but Nexus was not found under /opt/nexus or nexus.service is missing."
+}
+
+stop_nexus(){
+  systemctl stop nexus.service >/dev/null 2>&1 &
+  local p=$!
+  for _ in {1..10}; do
+    systemctl is-active --quiet nexus.service || { wait "$p" 2>/dev/null || true; return 0; }
+    sleep 1
+  done
+  systemctl kill --kill-whom=all --signal=SIGKILL nexus.service >/dev/null 2>&1 || true
+  wait "$p" 2>/dev/null || true
+}
+
+restart_nexus(){ stop_nexus; systemctl reset-failed nexus.service >/dev/null 2>&1 || true; systemctl start nexus.service; }
+
+wait_http(){
+  local max="${1:-45}"
+  for ((i=0;i<max;i++)); do curl -fsS --max-time 1 "$NEXUS_URL/" >/dev/null 2>&1 && return 0; sleep 1; done
+  return 1
+}
+
+configure_plasma_gate(){
+  [[ "$WAIT_FOR_PLASMA" -eq 1 ]] || return 0
+  if ! pgrep -u "$DESKTOP_UID" -x plasmashell >/dev/null 2>&1; then
+    warn "Plasma is not running for $DESKTOP_USER; tray startup workaround skipped."
+    return 0
+  fi
+  install -d -m 0755 "$DROPIN_DIR"
+  cat > "$DROPIN_DIR/10-wait-for-plasma.conf" <<EOF
+# Managed by nexus-linux-setup. Nexus currently adopts the graphical user
+# session at startup; on Plasma, starting before plasmashell can leave no tray.
+[Service]
+ExecStartPre=/bin/sh -c 'i=0; while [ \$\$i -lt 30 ]; do i=\$\$((i + 1)); pgrep -u ${DESKTOP_UID} -x plasmashell >/dev/null 2>&1 && exit 0; sleep 1; done; exit 0'
+EOF
+  log "Configured Nexus to wait up to 30 seconds for Plasma user ${DESKTOP_USER} (UID ${DESKTOP_UID})."
+}
+
+find_nct_pwm(){
+  local h n
+  for h in /sys/class/hwmon/hwmon*; do
+    [[ -r "$h/name" ]] || continue
+    n="$(cat "$h/name" 2>/dev/null || true)"
+    case "$n" in
+      nct6775|nct6776|nct6779|nct6791|nct6792|nct6793|nct6795|nct6796|nct6797|nct6798|nct6799)
+        compgen -G "$h/pwm[0-9]" >/dev/null && { printf '%s\n' "$h"; return 0; }
+        ;;
+    esac
+  done
+  return 1
+}
+
+configure_fans(){
+  FAN_MODULE=""
+  modinfo nct6775 >/dev/null 2>&1 || { log "nct6775 is unavailable; leaving fan discovery to Nexus/kernel defaults."; return 0; }
+  modprobe nct6775 >/dev/null 2>&1 || { warn "nct6775 exists but could not be loaded."; return 0; }
+  sleep 1
+  local h; h="$(find_nct_pwm || true)"
+  [[ -n "$h" ]] || { log "nct6775 exposed no supported PWM hwmon controller; not persisting it."; return 0; }
+  FAN_MODULE="nct6775"
+  printf 'nct6775\n' > /etc/modules-load.d/nexus-fans.conf
+  install -d -m 0755 "$DROPIN_DIR"
+  cat > "$DROPIN_DIR/20-nct6775.conf" <<'EOF'
+# Managed by nexus-linux-setup. Makes motherboard PWM channels available before
+# Nexus performs cooling enumeration. Discovery only; Nexus owns fan policy.
+[Service]
+ExecStartPre=/sbin/modprobe nct6775
+EOF
+  log "Detected $(cat "$h/name") PWM controller; nct6775 will be available before Nexus starts."
+}
+
+find_nexus_index(){
+  local a=() f
+  while IFS= read -r -d '' f; do
+    grep -qE 'assets/index-[A-Za-z0-9_-]+\.js' "$f" 2>/dev/null && a+=("$f")
+  done < <(find /opt/nexus -type f -name index.html -print0 2>/dev/null)
+  if [[ ${#a[@]} -ne 1 ]]; then warn "Expected one Nexus web index.html; found ${#a[@]}."; return 1; fi
+  printf '%s\n' "${a[0]}"
+}
+
+apply_web_patch(){
+  local idx js marker='<!-- BEGIN nexus-linux-setup simulator fix -->'
+  idx="$(find_nexus_index || true)"; [[ -n "$idx" ]] || return 0
+  js="$SHARE_DIR/simulator-fix.js"; [[ -r "$js" ]] || return 0
+  backup_file "$idx"
+  # Migrate the one-off local patch used during diagnosis so we never run two
+  # simulator shims at once.
+  INDEX="$idx" python3 <<'PYLEGACY'
+from pathlib import Path
+import os,re
+p=Path(os.environ['INDEX']); t=p.read_text(encoding='utf-8')
+pat=re.compile(r'<!-- BEGIN nexus-y70-local-simulator-fix -->.*?<!-- END nexus-y70-local-simulator-fix -->\s*',re.S)
+n,c=pat.subn('',t,count=1)
+if c: p.write_text(n,encoding='utf-8')
+PYLEGACY
+  grep -Fq "$marker" "$idx" && return 0
+  INDEX="$idx" JSFILE="$js" python3 <<'PY'
+from pathlib import Path
+import os
+p=Path(os.environ['INDEX']); js=Path(os.environ['JSFILE']).read_text(encoding='utf-8')
+text=p.read_text(encoding='utf-8')
+b='<!-- BEGIN nexus-linux-setup simulator fix -->'; e='<!-- END nexus-linux-setup simulator fix -->'
+block=f'{b}\n<script id="nexus-linux-setup-simulator-fix">\n{js}\n</script>\n{e}\n'
+if b in text: raise SystemExit(0)
+needle='</head>' if '</head>' in text else '</body>'
+if needle not in text: raise SystemExit('Nexus index has neither </head> nor </body>')
+p.write_text(text.replace(needle, block+needle, 1), encoding='utf-8')
+PY
+  log "Applied reversible local Y70 simulator handshake workaround."
+}
+
+remove_web_patch(){
+  local idx; idx="$(find_nexus_index || true)"; [[ -n "$idx" ]] || return 0
+  INDEX="$idx" python3 <<'PY'
+from pathlib import Path
+import os,re
+p=Path(os.environ['INDEX']); t=p.read_text(encoding='utf-8')
+pat=re.compile(r'<!-- BEGIN nexus-linux-setup simulator fix -->.*?<!-- END nexus-linux-setup simulator fix -->\s*',re.S)
+n,c=pat.subn('',t,count=1)
+if c: p.write_text(n,encoding='utf-8')
+PY
+}
+
+configure_web_patch(){
+  install -d -m 0755 "$DROPIN_DIR"
+  cat > "$DROPIN_DIR/15-y70-simulator.conf" <<EOF
+# Managed by nexus-linux-setup. Official updates can replace wwwroot/index.html,
+# so reapply the marked/reversible local workaround before service start.
+[Service]
+ExecStartPre=${LIBEXEC} internal-apply-web-patch
+EOF
+  apply_web_patch
+}
+
+settings_file(){ local f="$DESKTOP_HOME/.config/Nexus/settings.json"; [[ -f "$f" ]] && printf '%s\n' "$f"; }
+
+set_auto_launch(){
+  local val="$1" f; f="$(settings_file || true)"; [[ -n "$f" ]] || return 1
+  backup_file "$f"
+  FILE="$f" VALUE="$val" python3 <<'PY'
+from pathlib import Path
+import json,os
+p=Path(os.environ['FILE']); data=json.loads(p.read_text(encoding='utf-8'))
+data.setdefault('panel',{})['autoLaunch']=os.environ['VALUE'].lower()=='true'
+p.write_text(json.dumps(data,indent=2,ensure_ascii=False)+'\n',encoding='utf-8')
+PY
+  chown "$DESKTOP_UID:$DESKTOP_GID" "$f" 2>/dev/null || true
+}
+
+detect_existing_panel_id(){
+  [[ -n "${NEXUS_PANEL_ID:-}" ]] && { printf '%s\n' "$NEXUS_PANEL_ID"; return; }
+  [[ -n "${PANEL_ID:-}" ]] && { printf '%s\n' "$PANEL_ID"; return; }
+  local u="$DESKTOP_HOME/.config/systemd/user/nexus-y70-direct.service" launcher="$DESKTOP_HOME/.local/bin/nexus-y70-direct" id pid cmd
+  if [[ -r "$u" ]]; then
+    id="$(grep -oE '/panel/[A-Za-z0-9_-]+' "$u" | head -1 | cut -d/ -f3 || true)"
+    case "$id" in ''|phone|q60|devices) ;; *) printf '%s\n' "$id"; return ;; esac
+  fi
+  if [[ -r "$launcher" ]]; then
+    id="$(grep -oE '/panel/[A-Za-z0-9_-]+' "$launcher" | head -1 | cut -d/ -f3 || true)"
+    case "$id" in ''|phone|q60|devices) ;; *) printf '%s\n' "$id"; return ;; esac
+  fi
+  for pid in /proc/[0-9]*; do
+    [[ "$(stat -c %u "$pid" 2>/dev/null || echo x)" == "$DESKTOP_UID" ]] || continue
+    [[ -r "$pid/cmdline" ]] || continue
+    cmd="$(tr '\0' ' ' < "$pid/cmdline" 2>/dev/null || true)"
+    if [[ "$cmd" =~ localhost:9400/panel/([A-Za-z0-9_-]+) ]]; then
+      id="${BASH_REMATCH[1]}"; case "$id" in phone|q60|devices) ;; *) printf '%s\n' "$id"; return ;; esac
+    fi
+  done
+  return 1
+}
+
+capture_kiosk_token(){
+  local end=$((SECONDS+40)) pid cmd url token
+  while (( SECONDS < end )); do
+    for pid in /proc/[0-9]*; do
+      [[ "$(stat -c %u "$pid" 2>/dev/null || echo x)" == "$DESKTOP_UID" ]] || continue
+      [[ -r "$pid/cmdline" ]] || continue
+      cmd="$(tr '\0' ' ' < "$pid/cmdline" 2>/dev/null || true)"
+      [[ "$cmd" == *"localhost:9400/panel"*"?token="* ]] || continue
+      url="$(grep -oE 'http://localhost:9400/panel[^ ]*\?token=[^ ]+' <<<"$cmd" | head -1 || true)"
+      [[ -n "$url" ]] || continue
+      token="$(URL="$url" python3 - <<'PY'
+import os,urllib.parse
+u=urllib.parse.urlsplit(os.environ['URL']); print(urllib.parse.parse_qs(u.query).get('token',[''])[0])
+PY
+)"
+      [[ -n "$token" ]] && { printf '%s\n' "$token"; return 0; }
+    done
+    sleep 1
+  done
+  return 1
+}
+
+select_y70_record(){
+  local token="$1" data tmp
+  tmp="$(mktemp)"
+  curl -fsS -H "Authorization: Bearer ${token}" "$NEXUS_URL/panel/devices" -o "$tmp" || { rm -f "$tmp"; return 1; }
+  python3 - "$tmp" <<'PY'
+import json,sys
+with open(sys.argv[1],encoding='utf-8') as f: x=json.load(f)
+d=x.get('devices',[]) if isinstance(x,dict) else x
+c=[]
+for r in d if isinstance(d,list) else []:
+    if not isinstance(r,dict): continue
+    cap=r.get('capabilities') or {}
+    if cap.get('surface')!='y70': continue
+    w,h=cap.get('cssWidth') or 0,cap.get('cssHeight') or 0
+    ar=max(w,h)/max(1,min(w,h)) if w and h else 0
+    score=(3 if ar>=2.5 else 0)+(2 if 'y70' in (r.get('displayName') or '').lower() else 0)+(1 if not r.get('displayId') else 0)
+    c.append((score,r.get('lastSeenAt') or '',r.get('id') or ''))
+if not c: raise SystemExit(2)
+if len(c) != 1: raise SystemExit('Multiple Y70 records; set NEXUS_PANEL_ID explicitly')
+print(c[0][2])
+PY
+  local rc=$?; rm -f "$tmp"; return "$rc"
+}
+
+find_chrome(){
+  if [[ -n "${NEXUS_CHROME:-}" && -x "$NEXUS_CHROME" ]]; then printf '%s\n' "$NEXUS_CHROME"; return; fi
+  local c; for c in /opt/google/chrome/chrome /usr/bin/google-chrome /usr/bin/google-chrome-stable /usr/bin/chromium /usr/bin/chromium-browser; do [[ -x "$c" ]] && { printf '%s\n' "$c"; return; }; done
+  return 1
+}
+
+detect_y70_output(){
+  command -v kscreen-doctor >/dev/null 2>&1 || return 1
+  local tmp; tmp="$(mktemp)"; as_user kscreen-doctor -o > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  python3 - "$tmp" <<'PY'
+import re,sys
+s=open(sys.argv[1],encoding='utf-8',errors='ignore').read(); starts=[m.start() for m in re.finditer(r'(?m)^Output:',s)]
+c=[]
+for i,p in enumerate(starts):
+    b=s[p: starts[i+1] if i+1<len(starts) else len(s)]
+    m=re.search(r'^Output:\s*(?:\d+\s+)?(\S+)',b,re.M); g=re.search(r'Geometry:\s*(-?\d+),(-?\d+)\s+(\d+)x(\d+)',b)
+    if not m or not g: continue
+    name=m.group(1); x,y,w,h=map(int,g.groups()); native='3840x1100' in b; tall=h/max(1,w)>=2.5
+    if native or tall: c.append((2 if native else 1,name,x,y,w,h))
+if not c: raise SystemExit(2)
+c.sort(reverse=True)
+if len(c)>1 and c[0][0]==c[1][0]: raise SystemExit(3)
+_,n,x,y,w,h=c[0]; print(n); print(f'{x},{y},{w},{h}')
+PY
+  local rc=$?; rm -f "$tmp"; return "$rc"
+}
+
+existing_profile(){
+  local u="$DESKTOP_HOME/.config/systemd/user/nexus-y70-direct.service" launcher="$DESKTOP_HOME/.local/bin/nexus-y70-direct" p=""
+  if [[ -r "$u" ]]; then p="$(grep -oE -- '--user-data-dir=[^[:space:]]+' "$u" | head -1 | cut -d= -f2- || true)"; fi
+  if [[ -z "$p" && -r "$launcher" ]]; then p="$(grep -oE -- '--user-data-dir=[^[:space:]]+' "$launcher" | head -1 | cut -d= -f2- || true)"; fi
+  [[ -n "$p" ]] && { printf '%s\n' "$p"; return 0; }
+  [[ -n "${KIOSK_PROFILE:-}" ]] && { printf '%s\n' "$KIOSK_PROFILE"; return 0; }
+  return 1
+}
+
+kill_generic_kiosks(){
+  local pid cmd
+  for pid in /proc/[0-9]*; do
+    [[ "$(stat -c %u "$pid" 2>/dev/null || echo x)" == "$DESKTOP_UID" ]] || continue
+    [[ -r "$pid/cmdline" ]] || continue
+    cmd="$(tr '\0' ' ' < "$pid/cmdline" 2>/dev/null || true)"
+    if [[ "$cmd" == *"--app=http://localhost:9400/panel"* ]] && [[ "$cmd" == *"--kiosk"* ]]; then kill "${pid#/proc/}" 2>/dev/null || true; fi
+  done
+}
+
+write_kwin_script(){
+  local dir="$DESKTOP_HOME/.local/share/kwin/scripts/nexus-y70-placement"
+  install -d -o "$DESKTOP_UID" -g "$DESKTOP_GID" -m 0755 "$dir/contents/code"
+  cat > "$dir/metadata.json" <<'EOF'
+{
+  "KPlugin": {
+    "Id": "nexus-y70-placement",
+    "Name": "Nexus Y70 placement",
+    "Description": "Keeps the managed Nexus Y70 kiosk on its existing output",
+    "Version": "1.0.0",
+    "License": "MIT"
+  },
+  "X-Plasma-API": "javascript",
+  "X-Plasma-MainScript": "code/main.js"
+}
+EOF
+  cat > "$dir/contents/code/main.js" <<EOF
+// Managed by nexus-linux-setup. KWin 6.
+const TARGET_OUTPUT = $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$Y70_OUTPUT");
+const PANEL_ID = $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$PANEL_ID");
+const EXPECTED_CLASS = "chrome-localhost__panel_" + PANEL_ID + "-Default";
+function targetOutput() { return workspace.screens.find(o => o.name === TARGET_OUTPUT) || null; }
+function matches(w) { return String(w.resourceClass || "") === EXPECTED_CLASS || String(w.resourceName || "") === EXPECTED_CLASS; }
+function place(w) {
+  if (!matches(w)) return;
+  const out = targetOutput(); if (!out) return;
+  try { w.fullScreen = false; } catch (_) {}
+  try { workspace.sendClientToScreen(w, out); } catch (_) {}
+  const g = out.geometry;
+  try { w.frameGeometry = Qt.rect(g.x, g.y, g.width, g.height); } catch (_) {}
+  try { w.noBorder = true; } catch (_) {}
+  try { w.skipTaskbar = true; } catch (_) {}
+  try { w.skipPager = true; } catch (_) {}
+  try { w.skipSwitcher = true; } catch (_) {}
+  try { w.fullScreen = true; } catch (_) {}
+}
+function attach(w) {
+  if (!matches(w)) return; place(w);
+  try { w.outputChanged.connect(() => place(w)); } catch (_) {}
+  try { w.windowClassChanged.connect(() => place(w)); } catch (_) {}
+}
+workspace.stackingOrder.forEach(attach);
+workspace.windowAdded.connect(attach);
+workspace.screensChanged.connect(() => workspace.stackingOrder.forEach(place));
+EOF
+  chown -R "$DESKTOP_UID:$DESKTOP_GID" "$dir"
+  command -v kwriteconfig6 >/dev/null 2>&1 && as_user kwriteconfig6 --file kwinrc --group Plugins --key nexus-y70-placementEnabled true || true
+  command -v qdbus6 >/dev/null 2>&1 && as_user qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1 || true
+  log "Installed KWin placement helper for Y70 output $Y70_OUTPUT."
+}
+
+seed_profile(){
+  local token="$1"
+  install -d -o "$DESKTOP_UID" -g "$DESKTOP_GID" "$KIOSK_PROFILE"
+  log "Seeding dedicated Y70 Chrome profile once (token is not written to a unit or state file)..."
+  as_user "$CHROME_BIN" --ozone-platform=wayland --app="$NEXUS_URL/panel/$PANEL_ID?token=$token" --kiosk --password-store=basic --no-first-run --noerrdialogs --disable-session-crashed-bubble --user-data-dir="$KIOSK_PROFILE" >/dev/null 2>&1 &
+  local p=$!; sleep 6; kill "$p" 2>/dev/null || true; sleep 1
+  touch "$KIOSK_PROFILE/.nexus-linux-setup-seeded"; chown "$DESKTOP_UID:$DESKTOP_GID" "$KIOSK_PROFILE/.nexus-linux-setup-seeded"
+}
+
+write_y70_service(){
+  local bindir="$DESKTOP_HOME/.local/bin" unitdir="$DESKTOP_HOME/.config/systemd/user" bin="$DESKTOP_HOME/.local/bin/nexus-y70-direct"
+  install -d -o "$DESKTOP_UID" -g "$DESKTOP_GID" -m 0755 "$bindir" "$unitdir"
+  cat > "$bin" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+for _ in {1..60}; do
+  curl -fsS --max-time 1 http://localhost:9400/ >/dev/null 2>&1 && break
+  sleep 1
+done
+exec $(printf '%q' "$CHROME_BIN") \\
+  --ozone-platform=wayland \\
+  --app="http://localhost:9400/panel/$PANEL_ID" \\
+  --kiosk \\
+  --password-store=basic \\
+  --no-first-run \\
+  --noerrdialogs \\
+  --disable-session-crashed-bubble \\
+  --user-data-dir=$(printf '%q' "$KIOSK_PROFILE")
+EOF
+  chmod 0755 "$bin"; chown "$DESKTOP_UID:$DESKTOP_GID" "$bin"
+  cat > "$unitdir/nexus-y70-direct.service" <<EOF
+[Unit]
+Description=Nexus direct Y70 panel
+After=graphical-session.target
+Wants=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart="${bin//%/%%}"
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+EOF
+  chown "$DESKTOP_UID:$DESKTOP_GID" "$unitdir/nexus-y70-direct.service"
+  as_user systemctl --user daemon-reload
+  as_user systemctl --user enable nexus-y70-direct.service >/dev/null
+}
+
+configure_y70(){
+  [[ "$NO_Y70" -eq 0 ]] || { log "Y70 integration skipped."; return 0; }
+  pgrep -u "$DESKTOP_UID" -x plasmashell >/dev/null 2>&1 || { warn "No active Plasma session; Y70 setup skipped for now. Run repair after login."; return 0; }
+  local det profile token=""
+  det="$(detect_y70_output || true)"; [[ -n "$det" ]] || { warn "No unambiguous Y70-shaped KScreen output found; not guessing."; return 0; }
+  Y70_OUTPUT="$(sed -n '1p' <<<"$det")"; Y70_GEOMETRY="$(sed -n '2p' <<<"$det")"
+  log "Detected Y70 output $Y70_OUTPUT at $Y70_GEOMETRY; KScreen settings will not be changed."
+
+  PANEL_ID="$(detect_existing_panel_id || true)"
+  profile="$(existing_profile || true)"
+
+  if [[ -z "$PANEL_ID" ]]; then
+    log "No existing direct panel record found; bootstrapping from Nexus's own authenticated kiosk."
+    set_auto_launch true || { warn "Nexus settings.json not ready; open Nexus once, finish onboarding, then rerun repair."; return 0; }
+    restart_nexus; wait_http 45 || die "Nexus did not become reachable"
+    token="$(capture_kiosk_token || true)"; [[ -n "$token" ]] || die "Could not obtain the one-time local kiosk token. Open Nexus once and rerun repair."
+    PANEL_ID="$(select_y70_record "$token" || true)"; [[ -n "$PANEL_ID" ]] || die "Could not select a Y70 panel record from Nexus."
+  else
+    log "Using existing Y70 panel record $PANEL_ID."
+  fi
+
+  [[ "$PANEL_ID" =~ ^[A-Za-z0-9_-]+$ ]] || die "Invalid panel record ID"
+
+  CHROME_BIN="$(find_chrome || true)"; [[ -n "$CHROME_BIN" ]] || die "Chrome/Chromium executable not found"
+  if [[ -n "$profile" && -d "$profile" ]]; then KIOSK_PROFILE="$profile"; else KIOSK_PROFILE="$DESKTOP_HOME/nexus-kiosk/y70-direct"; fi
+
+  write_kwin_script
+  set_auto_launch false || die "Could not disable Nexus generic panel auto-launch"
+  kill_generic_kiosks
+
+  if [[ ! -e "$KIOSK_PROFILE/.nexus-linux-setup-seeded" && -z "$profile" ]]; then
+    if [[ -z "$token" ]]; then
+      set_auto_launch true || true; restart_nexus; wait_http 30 || true
+      token="$(capture_kiosk_token || true)"
+      set_auto_launch false || true; kill_generic_kiosks
+    fi
+    [[ -n "$token" ]] || die "Could not seed the dedicated Y70 profile without a one-time local token"
+    seed_profile "$token"
+  fi
+
+  configure_web_patch
+  write_y70_service
+  as_user systemctl --user restart nexus-y70-direct.service
+  token=""
+  log "Persistent direct Y70 kiosk configured at /panel/$PANEL_ID using localhost."
+}
+
+doctor_line(){ printf '%-6s %-27s %s\n' "$1" "$2" "$3"; }
+
+doctor(){
+  init_user; load_state; local fail=0 h idx id l
+  systemctl is-active --quiet nexus.service && doctor_line PASS "Nexus service" active || { doctor_line FAIL "Nexus service" inactive; fail=1; }
+  curl -fsS --max-time 2 "$NEXUS_URL/" >/dev/null 2>&1 && doctor_line PASS "Nexus dashboard" localhost:9400 || { doctor_line FAIL "Nexus dashboard" unreachable; fail=1; }
+
+  if pgrep -u "$DESKTOP_UID" -x plasmashell >/dev/null 2>&1; then
+    [[ -f "$DROPIN_DIR/10-wait-for-plasma.conf" ]] && doctor_line PASS "Plasma/tray startup" "gate installed" || doctor_line WARN "Plasma/tray startup" "gate absent"
+  else doctor_line WARN "Plasma/tray startup" "plasmashell not running"; fi
+
+  h="$(find_nct_pwm || true)"
+  if [[ -n "$h" ]]; then doctor_line PASS "Motherboard PWM" "$(cat "$h/name") exposed"; else doctor_line WARN "Motherboard PWM" "no supported NCT PWM hwmon found"; fi
+  l="$(journalctl -u nexus -b --no-pager 2>/dev/null | grep -E '\[Motherboard\].*Fans channels=[1-9]' | tail -1 || true)"
+  [[ -n "$l" ]] && doctor_line PASS "Nexus fan enumeration" "${l##*: }" || doctor_line WARN "Nexus fan enumeration" "no motherboard fan line this boot"
+
+  idx="$(find_nexus_index || true)"
+  [[ -n "$idx" ]] && grep -Fq '<!-- BEGIN nexus-linux-setup simulator fix -->' "$idx" && doctor_line PASS "Y70 simulator patch" installed || doctor_line WARN "Y70 simulator patch" absent
+
+  id="${PANEL_ID:-}"; [[ -n "$id" ]] || id="$(detect_existing_panel_id || true)"
+  if [[ -n "$id" ]]; then
+    as_user systemctl --user is-active --quiet nexus-y70-direct.service && doctor_line PASS "Y70 direct service" "active ($id)" || { doctor_line FAIL "Y70 direct service" "inactive ($id)"; fail=1; }
+    pgrep -u "$DESKTOP_UID" -af chrome 2>/dev/null | grep -Fq "localhost:9400/panel/$id" && doctor_line PASS "Y70 direct kiosk" "correct direct route" || doctor_line WARN "Y70 direct kiosk" "route not found in Chrome process list"
+  else doctor_line WARN "Y70 direct service" "not configured"; fi
+
+  journalctl -u nexus -b --no-pager 2>/dev/null | grep -qiE 'lighting|openrgb' && doctor_line PASS "Lighting subsystem" "journal activity present" || doctor_line WARN "Lighting subsystem" "no lighting/OpenRGB journal match"
+  return "$fail"
+}
+
+status_cmd(){
+  init_user; load_state
+  printf '%s %s\n' "$PROJECT" "$VERSION"
+  printf 'desktop user: %s (%s)\n' "$DESKTOP_USER" "$DESKTOP_UID"
+  printf 'panel id: %s\n' "${PANEL_ID:-not set}"
+  printf 'Y70 output: %s\n' "${Y70_OUTPUT:-not set}"
+  printf 'fan module: %s\n' "${FAN_MODULE:-not set}"
+  doctor || true
+}
+
+install_all(){
+  need_root install
+  init_user; ensure_dirs; install_self; install_official_nexus
+  configure_plasma_gate; configure_fans
+  systemctl daemon-reload; restart_nexus; wait_http 45 || die "Nexus did not become reachable after setup"
+  configure_y70; save_state
+  log "Installation/setup complete."; doctor
+}
+
+repair_all(){
+  need_root repair
+  init_user; ensure_dirs; load_state; install_self
+  nexus_installed || die "Nexus is not installed; use install"
+  configure_plasma_gate; configure_fans
+  systemctl daemon-reload; restart_nexus; wait_http 45 || die "Nexus did not become reachable after repair"
+  configure_y70; save_state
+  log "Repair complete."; doctor
+}
+
+uninstall_integration(){
+  need_root uninstall
+  init_user; load_state
+  as_user systemctl --user disable --now nexus-y70-direct.service >/dev/null 2>&1 || true
+  rm -f "$DESKTOP_HOME/.config/systemd/user/nexus-y70-direct.service" "$DESKTOP_HOME/.local/bin/nexus-y70-direct"
+  as_user systemctl --user daemon-reload >/dev/null 2>&1 || true
+  rm -rf "$DESKTOP_HOME/.local/share/kwin/scripts/nexus-y70-placement"
+  command -v kwriteconfig6 >/dev/null 2>&1 && as_user kwriteconfig6 --file kwinrc --group Plugins --delete nexus-y70-placementEnabled >/dev/null 2>&1 || true
+  command -v qdbus6 >/dev/null 2>&1 && as_user qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1 || true
+  remove_web_patch
+  rm -f "$DROPIN_DIR/10-wait-for-plasma.conf" "$DROPIN_DIR/15-y70-simulator.conf" "$DROPIN_DIR/20-nct6775.conf" /etc/modules-load.d/nexus-fans.conf
+  set_auto_launch true >/dev/null 2>&1 || true
+  systemctl daemon-reload
+  nexus_installed && restart_nexus || true
+  if [[ "$PURGE_NEXUS" -eq 1 ]]; then
+    local u; u="$(find /opt/nexus -maxdepth 2 -type f -name 'uninstall*.sh' -print | head -1 || true)"
+    [[ -n "$u" ]] && bash "$u" || warn "No official Nexus uninstaller found; Nexus left installed."
+  fi
+  rm -f "$LIBEXEC"; rm -rf "$SHARE_DIR"
+  log "Helper integration removed. Nexus user data and the dedicated kiosk profile were preserved."
+}
+
+internal_apply(){ ensure_dirs; apply_web_patch; }
+
+# Sourcing exposes functions for isolated tests; it never dispatches a command.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then return 0; fi
+
+cmd="${1:-}"; [[ $# -gt 0 ]] && shift || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) [[ $# -ge 2 ]] || die "--version needs a value"; NEXUS_VERSION="$2"; shift 2 ;;
+    --archive) [[ $# -ge 2 ]] || die "--archive needs a file"; LOCAL_ARCHIVE="$2"; shift 2 ;;
+    --update) FORCE_UPDATE=1; shift ;;
+    --no-y70) NO_Y70=1; shift ;;
+    --wait-for-plasma) WAIT_FOR_PLASMA=1; shift ;;
+    --purge-nexus) PURGE_NEXUS=1; shift ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown option: $1" ;;
+  esac
+done
+
+case "$cmd" in
+  install) install_all ;;
+  repair) repair_all ;;
+  doctor) need_root doctor; doctor ;;
+  status) need_root status; status_cmd ;;
+  uninstall) uninstall_integration ;;
+  internal-apply-web-patch) internal_apply ;;
+  -h|--help|'') usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/scripts/linux-setup/tests/helper.sh
+++ b/scripts/linux-setup/tests/helper.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source ./nexus-linux-setup.sh
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# The archive path must be the only stdout, even with progress logging enabled.
+curl() {
+  local dest=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == -o ]]; then dest="$2"; shift; fi
+    shift
+  done
+  if [[ "$dest" == */releases.json ]]; then
+    cat > "$dest" <<'JSON'
+[{"tag_name":"v1","assets":[{"name":"nexus-linux-x64.tar.gz","browser_download_url":"https://example.invalid/archive"}]}]
+JSON
+  else touch "$dest"; fi
+}
+archive="$(download_official_archive "$scratch")"
+[[ "$archive" == "$scratch/nexus.tar.gz" && -f "$archive" ]]
+NEXUS_VERSION=v-missing
+if select_release_asset "$scratch/releases.json"; then exit 1; fi
+NEXUS_VERSION=""
+
+# Test only generated configuration inside the fixture, never host services.
+DROPIN_DIR="$scratch/dropins"
+DESKTOP_UID=12345
+DESKTOP_USER=fixture
+pgrep() { return 0; }
+configure_plasma_gate
+[[ ! -e "$DROPIN_DIR" ]]
+WAIT_FOR_PLASMA=1
+configure_plasma_gate
+python3 - "$DROPIN_DIR/10-wait-for-plasma.conf" <<'PY'
+from pathlib import Path
+import sys
+text=Path(sys.argv[1]).read_text()
+assert 'while [ $$i -lt 30 ]' in text
+assert 'i=$$((i + 1))' in text
+assert 'pgrep -u 12345' in text
+assert 'done; exit 0' in text
+PY
+
+# Marked web patch is idempotent and removable without altering surrounding HTML.
+BACKUP_DIR="$scratch/backups"
+SHARE_DIR="$PWD/assets"
+mkdir -p "$BACKUP_DIR"
+printf '<html><head></head><body>fixture</body></html>\n' > "$scratch/index.html"
+cp "$scratch/index.html" "$scratch/original.html"
+find_nexus_index() { printf '%s\n' "$scratch/index.html"; }
+apply_web_patch
+cp "$scratch/index.html" "$scratch/once.html"
+apply_web_patch
+cmp "$scratch/index.html" "$scratch/once.html"
+remove_web_patch
+cmp "$scratch/index.html" "$scratch/original.html"
+# Reject ordinary landscape ultrawides and ambiguous panel associations.
+as_user() { printf '%s\n' "$screen_fixture"; }
+kscreen-doctor() { :; }
+screen_fixture='Output: 1 DP-fixture enabled connected
+Geometry: 0,0 3440x1440'
+if detect_y70_output; then exit 1; fi
+screen_fixture='Output: 1 DP-fixture enabled connected
+Geometry: 0,0 1100x3840'
+[[ "$(detect_y70_output)" == $'DP-fixture\n0,0,1100,3840' ]]
+curl() {
+  local dest=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == -o ]]; then dest="$2"; shift; fi
+    shift
+  done
+  printf '%s\n' "$record_fixture" > "$dest"
+}
+record_fixture='[{"id":"fixture-a","capabilities":{"surface":"y70"}}]'
+[[ "$(select_y70_record fixture-token)" == fixture-a ]]
+record_fixture='[{"id":"fixture-a","capabilities":{"surface":"y70"}},{"id":"fixture-b","capabilities":{"surface":"y70"}}]'
+if select_y70_record fixture-token; then exit 1; fi
+echo 'helper fixture tests passed'

--- a/scripts/linux-setup/tests/simulator.test.cjs
+++ b/scripts/linux-setup/tests/simulator.test.cjs
@@ -1,0 +1,52 @@
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const fs = require('node:fs');
+const path = require('node:path');
+const script = fs.readFileSync(path.join(__dirname, '../assets/simulator-fix.js'), 'utf8');
+function frame({pathname = '/panel', search = '?simulator=1', top = false} = {}) {
+  const messages = [], timers = new Map();
+  let listener, next = 0;
+  const parent = {};
+  const window = {parent, addEventListener: (_, fn) => listener = fn,
+    postMessage: (msg, origin) => messages.push({msg, origin})};
+  if (top) window.parent = window;
+  vm.runInNewContext(script, {window, location: {pathname, search, origin: 'http://localhost:9400'},
+    URLSearchParams, setTimeout: fn => {timers.set(++next, fn); return next;},
+    clearTimeout: id => timers.delete(id)});
+  return {messages, send: (data, origin = 'http://localhost:9400', source = window.parent) =>
+    listener?.({data, origin, source}), flush: () => {for (const [id, fn] of [...timers]) {timers.delete(id); fn();}}};
+}
+const theme = {type: 'simulator/set-theme', theme: {color: 'red'}};
+const layout = {type: 'simulator/set-layout', layout: {surface: 'y70', widgets: [{id: 'fixture'}]}};
+test('waits for both real values and initializes exactly once in either order', () => {
+  for (const events of [[theme, layout], [layout, theme]]) {
+    const f = frame(); f.send(events[0]); f.flush(); assert.equal(f.messages.length, 0);
+    f.send(events[1]); f.flush(); f.send(layout); f.flush();
+    assert.equal(f.messages.length, 1);
+    assert.equal(f.messages[0].msg.type, 'simulator/init');
+    assert.equal(f.messages[0].msg.layout.widgets[0].id, 'fixture');
+    assert.equal(f.messages[0].origin, 'http://localhost:9400');
+  }
+});
+test('real init cancels pending synthetic init', () => {
+  const f = frame(); f.send(theme); f.send(layout);
+  f.send({type: 'simulator/init', layout: layout.layout, theme: theme.theme}); f.flush();
+  assert.equal(f.messages.filter(x => x.msg.type === 'simulator/init').length, 0);
+});
+test('ignores foreign origins and non-parent sources', () => {
+  const f = frame(); f.send(theme, 'https://example.invalid'); f.send(layout); f.flush();
+  f.send(theme, 'http://localhost:9400', {}); f.flush(); assert.equal(f.messages.length, 0);
+});
+test('does not affect top-level pages, other routes or non-simulator frames', () => {
+  for (const options of [{top: true}, {pathname: '/panel/saved'}, {search: ''}]) {
+    const f = frame(options); f.send(theme); f.send(layout); f.flush(); assert.equal(f.messages.length, 0);
+  }
+});
+test('does not initialize or force visibility for phone layouts', () => {
+  const f = frame(); f.send(theme); f.send({type: 'simulator/set-layout', layout: {surface: 'phone'}});
+  f.send({type: 'simulator/set-display', showPanel: false}); f.flush(); assert.equal(f.messages.length, 0);
+});
+test('each iframe reload gets its own initialization', () => {
+  for (let i=0;i<2;i++) {const f=frame(); f.send(theme); f.send(layout); f.flush(); assert.equal(f.messages.length,1);}
+});

--- a/scripts/linux-setup/tests/static.sh
+++ b/scripts/linux-setup/tests/static.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+bash -n nexus-linux-setup.sh
+
+# Machine-specific values from the original reproduction must never leak into
+# reusable automation.
+if grep -R -nE 'N4gsrqVepcjt|/home/motto|DP-5|pgrep -u 1000' --exclude-dir=.git --exclude=static.sh .; then
+  echo "hard-coded reproduction identity found" >&2
+  exit 1
+fi
+
+# The generated direct kiosk must remain on localhost because Chrome app class
+# matching depends on the host name.
+grep -q 'http://localhost:9400/panel/' nexus-linux-setup.sh
+
+# The helper must not write raw PWM values.
+if grep -nE '>[[:space:]]*/sys/class/hwmon/.*/pwm|tee[[:space:]].*/sys/class/hwmon/.*/pwm' nexus-linux-setup.sh; then
+  echo "raw PWM write detected" >&2
+  exit 1
+fi
+
+echo "static checks passed"


### PR DESCRIPTION
## What & why

On my Kubuntu / Plasma 6 Wayland system with a HYTE Y70 Touch, getting Nexus working required several separate repairs: the physical panel could be treated as a phone during startup, the editor preview could stay blank, motherboard fans were missing, and the tray icon could be absent after login.

This PR brings the working recovery code from [my nexus-linux-setup repository](https://github.com/Ottomatic-Mike/nexus-linux-setup/tree/510cd4f) into this repository as an **optional Linux recovery helper**. It is an executable contribution with regression tests, not just a bug report. Nothing is added to the normal installer or run automatically.

### What users get

- **Y70 panel:** launch the existing saved panel directly and place its window on the configured output. This avoids using temporary browser dimensions to choose the panel identity and leaves monitor settings alone.
- **Blank editor:** a Y70-only fallback supplies the missing initial simulator message from the real theme and layout, unless the normal initialization arrives first.
- **Missing motherboard fans:** load `nct6775`, persist it only when supported PWM channels actually appear, and restart Nexus so it can discover them. The helper does not write fan duty values.
- **Missing Plasma tray:** an explicit `--wait-for-plasma` option waits up to 30 seconds for the desktop before service startup.
- Install/repair, diagnostics, update-time reapplication, backups and uninstall commands from the original work.

### Where to start reviewing

1. [`docs/linux-recovery.md`](docs/linux-recovery.md): short explanation mapping each failure to its recovery and the longer-term fix.
2. [`scripts/linux-setup/nexus-linux-setup.sh`](scripts/linux-setup/nexus-linux-setup.sh) and its simulator asset: the implementation.
3. [`scripts/linux-setup/tests`](scripts/linux-setup/tests): isolated tests, also run by the new workflow without private submodules.

The main README only gains a link. The existing license, contribution guide, installer and submodule revisions are preserved; the imported helper retains its MIT notice.

### Improvements over my original helper

Download logs now go to stderr so they cannot corrupt the archive filename captured by the installer. The Plasma wait is opt-in and bounded. The simulator patch is installed with direct Y70 setup and only acts on explicit Y70 layouts. Panel IDs are validated; multiple Y70 records require an explicit selection; a landscape ultrawide is no longer selected by the portrait fallback. Browser output during token seeding is discarded, backup directories are private, and the helper no longer deletes the earlier diagnostic KWin script automatically.

### Scope and remaining work

`nexus-service` and `nexus-web` are still inaccessible with my contributor account. I therefore cannot honestly include or test changes to those components here. The PR includes the sanitized reproduction and concrete component follow-ups: stable physical-panel identity, complete iframe initialization, late fan-provider discovery, and retryable graphical-session adoption. The helper is a practical recovery path while those source-level fixes remain outstanding.

The original hardware recovery was verified on the Nexus 3.0.12 beta line, Plasma 6/Wayland, Y70 Touch and an ASUS X870E board with an NCT6799-compatible chip. This adapted PR was tested only with isolated fixtures; I did not run setup or change the working machine. Maintainer hardware testing is still needed for fresh install, login/resume, authentication, update and removal. Profile seeding uses a timed browser launch, and uninstall reenables panel auto-launch rather than restoring its previous value; these limitations are documented.

## Validation

Passed locally:

- `bash scripts/linux-setup/tests/static.sh`
- `bash scripts/linux-setup/tests/helper.sh` — archive output, absent release, optional/bounded Plasma gate, idempotent/removable HTML patch, portrait-output selection and ambiguous panel records.
- `node --test scripts/linux-setup/tests/simulator.test.cjs` — six tests covering message ordering, real-init cancellation, origin/source checks, route scope, non-Y70 isolation and iframe reload.
- `git diff --cached --check`

No host services, drivers, display settings or installed Nexus files were changed. Component builds/tests were unavailable because their source repositories are private.

## Checklist

- [x] I tested these changes locally (isolated tests above; no new hardware run)
- [x] I updated the relevant README where behavior, layout, or commands changed
- [x] Commit subjects follow conventional-commit style
